### PR TITLE
feat: provide a `get` command

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,22 +1,6 @@
 name: merge
 on: pull_request
 jobs:
-  udeps:
-    name: unused dependency check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-        with:
-          # cargo-udeps requires the nightly toolchain, which is why we need a separate job.
-          toolchain: nightly
-          components: rustfmt
-      - name: install cargo-udeps
-        run: cargo install cargo-udeps --locked
-      - name: run cargo-udeps
-        run: cargo +nightly udeps --all-targets
   lint:
     runs-on: ubuntu-latest
     env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,11 +328,13 @@ dependencies = [
  "dirs-next",
  "httpmock",
  "predicates",
+ "prettytable-rs",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_derive",
  "serde_json",
+ "textwrap",
  "thiserror",
  "tokio",
 ]
@@ -467,7 +469,7 @@ version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width",
@@ -488,6 +490,27 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "csv"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "ctor"
@@ -601,6 +624,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1501,6 +1530,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode 1.0.0",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2033,17 @@ name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -2182,6 +2242,16 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [
+ "hashbrown",
+ "regex",
+]
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,13 @@ clap = { version = "4.1.6", features = ["derive"] }
 color-eyre = "0.6.2"
 dialoguer = "0.10.4"
 dirs-next = "2.0.0"
+prettytable-rs = "0.10.0"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+textwrap = "0.16.0"
 thiserror = "1.0.23"
 tokio = { version = "1.26", features = ["full"] }
 

--- a/Justfile
+++ b/Justfile
@@ -39,15 +39,11 @@ build-release-artifacts arch:
   rm -rf artifacts
   mkdir artifacts
   cargo clean
-  if [[ $arch == arm* || $arch == armv7* || $arch == aarch64* ]]; then
+  if [[ $arch == aarch64* ]]; then
     cargo install cross
-    cross build --release --target $arch --bin safe
-    cross build --release --target $arch --bin safenode
-    cross build --release --target $arch --bin testnet
+    cross build --release --target $arch --bin books
   else
-    cargo build --release --target $arch --bin safe
-    cargo build --release --target $arch --bin safenode
-    cargo build --release --target $arch --bin testnet
+    cargo build --release --target $arch --bin books
   fi
 
   find target/$arch/release -maxdepth 1 -type f -exec cp '{}' artifacts \;

--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
 # books-db
 
-A simple command line application for maintaining a collection of books. It uses [ISBNdb](https://isbndb.com) as a data source and [SQLite](https://www.sqlite.org/index.html) for storage.
+This is a simple command line application for maintaining a collection of books. It uses [ISBNdb](https://isbndb.com) as a data source and [SQLite](https://www.sqlite.org/index.html) for storage.
 
 ## Setup
 
 Obtain an API key from ISBNdb and set this using the `ISBNDB_KEY` environment variable.
 
-If there is a need to edit any details of a book, an external editor will be used for this. Set the standard `EDITOR` or `VISUAL` variables to specify the editor you want to use.
+Edit-based commands will use an external editor. Use the standard `EDITOR` or `VISUAL` environment variables to specify which editor to use.
 
 Use the `init` command to create the database. On Linux, the file will be created at `~/.local/share/books-db/books.db`.
 
-## Adding a Book
+## Working with Books
 
-Use the `add` command to add a book to your database, providing the ISBN:
+### Get the ISBN Record
+
+Use the `get` command with the ISBN to display the ISBNdb record for the book:
+```
+books get 9780517597675
+```
+
+This will print the record without saving it as a book in your local database.
+
+### Add a Book to the Database
+
+Use the `add` command with the ISBN to save a book to your database:
 ```
 books add 9780517597675
 ```
 
-This will query the ISBNdb database and return the entry corresponding to the provided ISBN.
-
-Before the book is saved, you'll get an opportunity to edit any details provided by ISBNdb you'd rather change or not have, and also such things as adding a price or indicating whether you own the book.
+Before the book is saved, you'll get an opportunity to edit any details.

--- a/src/books.rs
+++ b/src/books.rs
@@ -84,12 +84,13 @@ impl BookRepository {
         let mut book = Book::try_from(model)?;
         book.publisher.id = crate::db::save_publisher(self.storage_path.clone(), &book.publisher)?;
         for mut author in book.authors.iter_mut() {
-            author.id = crate::db::save_author(self.storage_path.clone(), &author)?;
+            author.id = crate::db::save_author(self.storage_path.clone(), author)?;
         }
         book.id = crate::db::save_book(self.storage_path.clone(), &book)?;
         Ok(book)
     }
 
+    #[allow(dead_code)]
     pub fn get_by_id(&self, id: u32) -> Result<Book> {
         let book = crate::db::get_book(self.storage_path.clone(), id)?;
         Ok(book)
@@ -145,7 +146,7 @@ mod test {
         assert_eq!(book.binding, "Paperback");
         assert_eq!(book.isbn, "9780233050485");
         assert_eq!(book.pages, 352);
-        assert_eq!(book.owned, true);
+        assert!(book.owned);
         Ok(())
     }
 
@@ -193,7 +194,7 @@ mod test {
         assert_eq!(book.binding, "Hardcover");
         assert_eq!(book.isbn, "9780517597675");
         assert_eq!(book.pages, 322);
-        assert_eq!(book.owned, true);
+        assert!(book.owned);
         Ok(())
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -51,6 +51,7 @@ pub fn init_db(database_path: PathBuf) -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 pub fn get_book(database_path: PathBuf, id: u32) -> Result<Book> {
     let conn = Connection::open(database_path)?;
     let mut book = match conn.query_row(
@@ -222,7 +223,7 @@ mod test {
             .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
             .unwrap();
         let rows = statement
-            .query_map(&["publishers"], |row| row.get::<_, String>(0))
+            .query_map(["publishers"], |row| row.get::<_, String>(0))
             .unwrap();
         assert!(rows.count() > 0)
     }
@@ -239,7 +240,7 @@ mod test {
             .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
             .unwrap();
         let rows = statement
-            .query_map(&["authors"], |row| row.get::<_, String>(0))
+            .query_map(["authors"], |row| row.get::<_, String>(0))
             .unwrap();
         assert!(rows.count() > 0)
     }
@@ -256,7 +257,7 @@ mod test {
             .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
             .unwrap();
         let rows = statement
-            .query_map(&["books"], |row| row.get::<_, String>(0))
+            .query_map(["books"], |row| row.get::<_, String>(0))
             .unwrap();
         assert!(rows.count() > 0)
     }
@@ -273,7 +274,7 @@ mod test {
             .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
             .unwrap();
         let rows = statement
-            .query_map(&["books_authors"], |row| row.get::<_, String>(0))
+            .query_map(["books_authors"], |row| row.get::<_, String>(0))
             .unwrap();
         assert!(rows.count() > 0)
     }

--- a/src/isbn_db.rs
+++ b/src/isbn_db.rs
@@ -32,7 +32,7 @@ impl IsbnDbBook {
             Cell::new("Title"),
             Cell::new(&wrapped_title),
         ]));
-        if &self.title_long != &self.title {
+        if self.title_long != self.title {
             let wrapped_long_title = textwrap::wrap(&self.title_long, 72).join("\n");
             table.add_row(Row::new(vec![
                 Cell::new("Title (Long)"),
@@ -258,7 +258,7 @@ mod test {
             "Two Seconds Under the World:Terror Comes to America-The Conspiracy Behind the World Trade Center Bombing"
         );
         assert_eq!(book.isbn13, isbn);
-        assert_eq!(book.msrp, 24 as f32);
+        assert_eq!(book.msrp, 24_f32);
         assert_eq!(book.binding, "Hardcover");
         assert_eq!(book.isbn, "0517597675");
         assert_eq!(book.isbn10, "0517597675");

--- a/src/isbn_db.rs
+++ b/src/isbn_db.rs
@@ -1,5 +1,8 @@
 use color_eyre::Result;
+use prettytable::{Cell, Row, Table};
 use serde_json::Value;
+
+const WRAP_LENGTH: usize = 80;
 
 pub struct IsbnDbBook {
     pub publisher: String,
@@ -19,6 +22,88 @@ pub struct IsbnDbBook {
     pub isbn10: String,
     pub subjects: Option<Vec<String>>,
     pub synopsis: Option<String>,
+}
+
+impl IsbnDbBook {
+    pub fn print(&self) {
+        let mut table = Table::new();
+        let wrapped_title = textwrap::wrap(&self.title, WRAP_LENGTH).join("\n");
+        table.add_row(Row::new(vec![
+            Cell::new("Title"),
+            Cell::new(&wrapped_title),
+        ]));
+        if &self.title_long != &self.title {
+            let wrapped_long_title = textwrap::wrap(&self.title_long, 72).join("\n");
+            table.add_row(Row::new(vec![
+                Cell::new("Title (Long)"),
+                Cell::new(&wrapped_long_title),
+            ]));
+        }
+        table.add_row(Row::new(vec![
+            Cell::new("Author(s)"),
+            Cell::new(&self.authors.join("; ")),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("Date Published"),
+            Cell::new(&self.date_published),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("Binding"),
+            Cell::new(&self.binding),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("Edition"),
+            Cell::new(&self.edition),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("Pages"),
+            Cell::new(&self.pages.to_string()),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("Publisher"),
+            Cell::new(&self.publisher),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("Language"),
+            Cell::new(&self.language),
+        ]));
+
+        let wrapped_subjects = textwrap::wrap(
+            &self
+                .subjects
+                .as_ref()
+                .map(|subjects| subjects.join(", "))
+                .unwrap_or_else(|| "N/A".to_string()),
+            WRAP_LENGTH,
+        )
+        .join("\n");
+        table.add_row(Row::new(vec![
+            Cell::new("Subjects"),
+            Cell::new(&wrapped_subjects),
+        ]));
+
+        let wrapped_synopsis = textwrap::wrap(
+            self.synopsis.as_ref().unwrap_or(&"N/A".to_string()),
+            WRAP_LENGTH,
+        )
+        .join("\n");
+        table.add_row(Row::new(vec![
+            Cell::new("Synopsis"),
+            Cell::new(&wrapped_synopsis),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("MSRP"),
+            Cell::new(&self.msrp.to_string()),
+        ]));
+        table.add_row(Row::new(vec![Cell::new("ISBN13"), Cell::new(&self.isbn13)]));
+        table.add_row(Row::new(vec![Cell::new("ISBN"), Cell::new(&self.isbn)]));
+        table.add_row(Row::new(vec![Cell::new("ISBN10"), Cell::new(&self.isbn10)]));
+        table.add_row(Row::new(vec![
+            Cell::new("Dimensions"),
+            Cell::new(&self.dimensions),
+        ]));
+        table.printstd();
+    }
 }
 
 pub struct IsbnDbRepository {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,9 +28,18 @@ struct Cli {
 enum Commands {
     /// Create the database schema
     Init,
+    /// Get the ISBNdb record for a book
+    ///
+    /// This will print the record for the book on the ISBNdb without saving it to the local
+    /// database.
+    Get {
+        /// The book's ISBN
+        #[clap(name = "isbn")]
+        isbn: String,
+    },
     /// Add a book to the database
     Add {
-        /// The ISBN number of the book
+        /// The book's ISBN
         #[clap(name = "isbn")]
         isbn: String,
     },
@@ -52,6 +61,12 @@ async fn main() -> Result<(), Report> {
     let result = match cli.command {
         Some(Commands::Init) => {
             db::init_db(database_path)?;
+            Ok(())
+        }
+        Some(Commands::Get { isbn }) => {
+            let isbn_repo = IsbnDbRepository::new(ISBNDB_URL, &isbn_db_key);
+            let book = isbn_repo.get_book_by_isbn(&isbn).await?;
+            book.print();
             Ok(())
         }
         Some(Commands::Add { isbn }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Report> {
         }
     };
 
-    let result = match cli.command {
+    match cli.command {
         Some(Commands::Init) => {
             db::init_db(database_path)?;
             Ok(())
@@ -95,8 +95,7 @@ async fn main() -> Result<(), Report> {
             println!("No command provided. Please use --help to see a list of available commands.");
             Ok(())
         }
-    };
-    result
+    }
 }
 
 fn get_database_path(storage_path: Option<PathBuf>) -> Result<PathBuf> {

--- a/src/models.rs
+++ b/src/models.rs
@@ -58,7 +58,7 @@ impl FromStr for AddBookModel {
         let mut owned = None;
 
         for line in s.lines() {
-            let mut parts = line.splitn(2, ":");
+            let mut parts = line.splitn(2, ':');
             let key = parts.next();
             let value = parts.next().unwrap_or("").trim();
 
@@ -210,7 +210,7 @@ mod test {
         assert_eq!(model.isbn, "9780233050485");
         assert_eq!(model.binding, "Paperback");
         assert_eq!(model.authors, "Reeve, Simon");
-        assert_eq!(model.owned, true);
+        assert!(model.owned);
         Ok(())
     }
 
@@ -234,7 +234,7 @@ mod test {
             date_published: "1997".to_string(),
             title: "Two Seconds Under the World:Terror Comes to America-The Conspiracy Behind the World Trade Center Bombing".to_string(),
             isbn13: "9780517597675".to_string(),
-            msrp: 24 as f32,
+            msrp: 24_f32,
             binding: "Hardcover".to_string(),
             isbn: "0517597675".to_string(),
             isbn10: "0517597675".to_string(),
@@ -265,7 +265,7 @@ mod test {
             model.authors,
             "Dwyer, Jim; Murphy, Deidre; Tyre, Peg; Kocieniewski, David"
         );
-        assert_eq!(model.owned, true);
+        assert!(model.owned);
         // If the book is first edition, the original date should be set automatically.
         assert_eq!(model.original_date_published, Some("1997".to_string()));
         Ok(())
@@ -308,19 +308,17 @@ mod test {
 
     #[test]
     fn parse_should_convert_an_edited_book_string_to_an_add_book_model() {
-        let edited = format!(
-            "Author(s): Reeve, Simon\n\
-             Publisher: Carlton Publishing Group\n\
-             Title: The New Jackals: Osama Bin Laden and the Future of Terrorism\n\
-             Edition: 2nd\n\
-             Date Published: 2001\n\
-             Original Date Published: 1999\n\
-             Price: 20.0\n\
-             Binding: Paperback\n\
-             ISBN: 9780233050485\n\
-             Pages: 352\n\
-             Owned: true"
-        );
+        let edited = "Author(s): Reeve, Simon\n\
+         Publisher: Carlton Publishing Group\n\
+         Title: The New Jackals: Osama Bin Laden and the Future of Terrorism\n\
+         Edition: 2nd\n\
+         Date Published: 2001\n\
+         Original Date Published: 1999\n\
+         Price: 20.0\n\
+         Binding: Paperback\n\
+         ISBN: 9780233050485\n\
+         Pages: 352\n\
+         Owned: true";
 
         let model: AddBookModel = edited.parse().unwrap();
 
@@ -337,23 +335,21 @@ mod test {
         assert_eq!(model.binding, "Paperback");
         assert_eq!(model.isbn, "9780233050485");
         assert_eq!(model.pages, 352);
-        assert_eq!(model.owned, true);
+        assert!(model.owned);
     }
 
     #[test]
     fn parse_should_convert_an_edited_book_string_with_optional_fields_missing_to_an_add_book_model(
     ) {
-        let edited = format!(
-            "Author(s): Reeve, Simon\n\
-             Publisher: Carlton Publishing Group\n\
-             Title: The New Jackals: Osama Bin Laden and the Future of Terrorism\n\
-             Edition: 2nd\n\
-             Date Published: 2001\n\
-             Binding: Paperback\n\
-             ISBN: 9780233050485\n\
-             Pages: 352\n\
-             Owned: true"
-        );
+        let edited = "Author(s): Reeve, Simon\n\
+         Publisher: Carlton Publishing Group\n\
+         Title: The New Jackals: Osama Bin Laden and the Future of Terrorism\n\
+         Edition: 2nd\n\
+         Date Published: 2001\n\
+         Binding: Paperback\n\
+         ISBN: 9780233050485\n\
+         Pages: 352\n\
+         Owned: true";
 
         let model: AddBookModel = edited.parse().unwrap();
 
@@ -370,25 +366,23 @@ mod test {
         assert_eq!(model.binding, "Paperback");
         assert_eq!(model.isbn, "9780233050485");
         assert_eq!(model.pages, 352);
-        assert_eq!(model.owned, true);
+        assert!(model.owned);
     }
 
     #[test]
     fn parse_should_convert_an_edited_book_string_with_optional_fields_not_populated_to_an_add_book_model(
     ) {
-        let edited = format!(
-            "Author(s): Reeve, Simon\n\
-             Publisher: Carlton Publishing Group\n\
-             Title: The New Jackals: Osama Bin Laden and the Future of Terrorism\n\
-             Edition: 2nd\n\
-             Date Published: 2001\n\
-             Original Date Published:\n\
-             Price: \n\
-             Binding: Paperback\n\
-             ISBN: 9780233050485\n\
-             Pages: 352\n\
-             Owned: true"
-        );
+        let edited = "Author(s): Reeve, Simon\n\
+         Publisher: Carlton Publishing Group\n\
+         Title: The New Jackals: Osama Bin Laden and the Future of Terrorism\n\
+         Edition: 2nd\n\
+         Date Published: 2001\n\
+         Original Date Published:\n\
+         Price: \n\
+         Binding: Paperback\n\
+         ISBN: 9780233050485\n\
+         Pages: 352\n\
+         Owned: true";
 
         let model: AddBookModel = edited.parse().unwrap();
 
@@ -405,6 +399,6 @@ mod test {
         assert_eq!(model.binding, "Paperback");
         assert_eq!(model.isbn, "9780233050485");
         assert_eq!(model.pages, 352);
-        assert_eq!(model.owned, true);
+        assert!(model.owned);
     }
 }


### PR DESCRIPTION
- b0de90f **fix: use correct binary**

This code was copied from another repository and was using the binary names from that repo.

- e4decb7 **feat: provide a `get` command**

This command simply prints the details of the record for the book that's stored in the ISBNdb database.

It can be used to quickly check the details of a book without actually saving it to your database.

- 82abfa4 **chore: resolve clippy errors**

This was the first time that clippy had been run on this codebase.

I also removed the `udeps` job from the merge workflow because I was getting a bizarre compiler
error trying to build the code when using the nightly toolchain. This is unfortunate, but I don't
feel like spending time just now trying to resolve this issue.