### PR TITLE
chore: provide licensing information

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -42,6 +42,10 @@ jobs:
         run: |
           set -e
           release-plz update
+          if [[ -z $(git status --porcelain) ]]; then
+            echo "No changes were detected. Exiting without bumping the version."
+            exit 0
+          fi
           version=$(cat Cargo.toml | grep "^version" | awk -F '=' '{ print $2 }' | xargs)
           commit_message="chore: release $version"
           git add --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "books-db"
 version = "0.1.0"
 edition = "2021"
 authors = ["Chris O'Neil <chriso83@protonmail.com>"]
+description = "Simple command line application for maintaining a collection of books"
+license = "MIT"
 repository = "https://github.com/jacderida/books-db"
 
 [[bin]]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+Copyright 2003 Chris O'Neil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ books add 9780517597675
 ```
 
 Before the book is saved, you'll get an opportunity to edit any details.
+
+## License
+
+This repository is licensed under the MIT license.
+
+See the [LICENSE](LICENSE) file for more details.


### PR DESCRIPTION
- 3f71b263 **ci: do not version bump on no changes**

The script needs to exit if there are no changes produced by running `release-plz update`, otherwise
the `git commit` command will cause an error in the workflow.

- d2ad86b **chore: provide licensing information**

A license needs to be provided to successfully publish the crate.

The MIT license seems appropriate for this small project.